### PR TITLE
Fix data type error

### DIFF
--- a/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py
+++ b/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py
@@ -79,6 +79,7 @@ def extract_new_old_label(nwbfile):
     if not (labels.dtype == 'O'): #check Matlab data type
         new_old_labels = np.delete(labels, np.where(labels == 10)).astype(int)
     else: #Python
+        labels = labels.astype(str)
         new_old_labels = np.delete(labels, np.where(labels == 'NA')).astype(int)
 
     return new_old_labels
@@ -240,6 +241,7 @@ def cal_typecounter(nwbfile):
     if not (labels.dtype == 'O'):  # check Matlab data type
         new_old_labels = np.delete(labels, np.where(labels == 10)).astype(int)
     else:  # Python
+        labels = labels.astype(str)
         new_old_labels = np.delete(labels, np.where(labels == 'NA')).astype(int)
 
 


### PR DESCRIPTION
When running [DANDI Example Notebook 000004](https://github.com/dandi/example-notebooks/blob/master/000004/RutishauserLab/000004_demo_analysis.ipynb), I received the error below.  The proposed change resolved the error.

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[5], [line 6]
      [4] fig, axes = plt.subplots(1, 3, figsize = (25, 10))
      [5] # Calculate the cumulative d and plot the cumulative ROC curve
----> [6] stats_all = helper.cal_cumulative_d(nwb)
      [7] # Calculate the auc
      [8] auc = helper.cal_auc(stats_all)

File ~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:219, in cal_cumulative_d(nwbfile)
    [208](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:208) def cal_cumulative_d(nwbfile):
    [209](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:209)     """
    [210](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:210)     calculate cummulative d' values as well as z-transformed hit/false alarm rates. used to construct empirical ROCs constructed using different
    [211](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:211)     confidence ratings.
   (...)
    [217](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:217)     urut/oct06
    [218](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:218)     """
--> [219](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:219)     typecounter = cal_typecounter(nwbfile)
    [220](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:220)     n_old = np.sum(typecounter[0, :])
    [221](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:221)     n_new = np.sum(typecounter[3, :])

File ~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:245, in cal_typecounter(nwbfile)
    [242](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:242)     new_old_labels = np.delete(labels, np.where(labels == 10)).astype(int)
    [243](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:243) else:  # Python
    [244](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:244)     # labels = labels.astype(str)
--> [245](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:245)     new_old_labels = np.delete(labels, np.where(labels == 'NA')).astype(int)
    [250](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:250) typecounter = []
    [252](~/Documents/GitHub/recogmem-release-NWB/RutishauserLabtoNWB/events/newolddelay/python/analysis/helper.py:252) for i in range(6, 0, -1):

ValueError: invalid literal for int() with base 10: b'NA'
```