### PR TITLE
Fix dimension mismatch in raster_psth eventplot

### DIFF
--- a/RutishauserLabtoNWB/events/newolddelay/python/analysis/single_neuron.py
+++ b/RutishauserLabtoNWB/events/newolddelay/python/analysis/single_neuron.py
@@ -244,7 +244,7 @@ class Neuron:
                                                        (self.spike_timestamps < (trial.delay2_off))]-(-1000000+trial.stim_on)
                                  for trial in trials]
 
-            axs[0].eventplot(np.asarray(trials_timestamps) / 1000, colors=color_mapping)
+            axs[0].eventplot(([t/1000 for t in trials_timestamps]), colors=color_mapping)
             axs[0].axvspan(height_light_range[0], height_light_range[1], color='grey', alpha=0.1)
             axs[0].set_xlim(xlim[0], xlim[1])
             axs[0].set_ylabel('Trials')


### PR DESCRIPTION
Hi @sczcheng, I encountered the error below so I submitting this change based off of [Commit 42aad89](https://github.com/rutishauserlab/recogmem-release-NWB/commit/42aad89844456643e9a0e29a62eec6c8d9c1cb2d).  I am not sure if these changes are technically correct/desired in this context so please double check.  Thanks.

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[8], [line 12]
     [10] for neuron in neurons:
     [11]     neuron.raster_psth(cell_type='visual', bin_size = 150)
---> [12]     neuron.raster_psth(cell_type = 'memory', bin_size = 150)

File ~/miniconda3/envs/dandiexample4/lib/python3.11/site-packages/RutishauserLabtoNWB/events/newolddelay/python/analysis/single_neuron.py:247, in Neuron.raster_psth(self, height_light_range, xlim, cell_type, bin_size, smooth, saveFig)
    [242] color_mapping = [colors1[int(trial.response > 3)] for trial in trials]
    [243] trials_timestamps = [self.spike_timestamps[(self.spike_timestamps > (-1000000 + trial.stim_on)) &
    [244]                                            (self.spike_timestamps < (trial.delay2_off))]-(-1000000+trial.stim_on)
    [245]                      for trial in trials]
--> [247] axs[0].eventplot(np.asarray(trials_timestamps) / 1000, colors=color_mapping)
    [248] axs[0].axvspan(height_light_range[0], height_light_range[1], color='grey', alpha=0.1)
    [249] axs[0].set_xlim(xlim[0], xlim[1])

ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (100,) + inhomogeneous part.
```